### PR TITLE
Refactor CHeap

### DIFF
--- a/MatrixGame/src/MatrixGame.cpp
+++ b/MatrixGame/src/MatrixGame.cpp
@@ -128,7 +128,10 @@ int APIENTRY _tWinMain(HINSTANCE hInstance, HINSTANCE, LPTSTR, int) {
 #ifdef ENABLE_HISTORY
         CDebugTracer::SaveHistory();
 #endif
-        g_Cache->Clear();
+        if (g_Cache)
+        {
+            g_Cache->Clear();
+        }
         L3GDeinit();
 
         MessageBox(NULL, CStr(ex->Info()).Get(), "Exception:", MB_OK);

--- a/MatrixGame/src/MatrixSide.cpp
+++ b/MatrixGame/src/MatrixSide.cpp
@@ -2651,12 +2651,6 @@ void CMatrixSideUnit::TaktHL() {
 
     EscapeFromBomb();
 
-    /*static int lastsave=0;
-    if(timeGetTime()-lastsave>1000) {
-        lastsave=timeGetTime();
-        HListPrint(L"#save_mem.xls");
-    }*/
-
     // Расчет с кем воюем
 
     if (m_NextWarSideCalcTime < g_MatrixMap->GetTime()) {

--- a/MatrixLib/Base/CBlockPar.cpp
+++ b/MatrixLib/Base/CBlockPar.cpp
@@ -336,7 +336,7 @@ int CBlockPar::ArrayFindInsertIndex(CBlockParUnit *ael) {
 
 void CBlockPar::ArrayAdd(CBlockParUnit *el) {
     DTRACE();
-    m_Array = (CBlockParUnit **)HAllocClearEx(m_Array, (m_ArrayCnt + 1) * sizeof(CBlockParUnit *), m_Heap);
+    m_Array = (CBlockParUnit **)HAllocEx(m_Array, (m_ArrayCnt + 1) * sizeof(CBlockParUnit *), m_Heap);
 
     int no = ArrayFindInsertIndex(el);
     if (no >= m_ArrayCnt) {
@@ -366,7 +366,7 @@ void CBlockPar::ArrayDel(CBlockParUnit *el) {
             if (no < (m_ArrayCnt - 1))
                 MoveMemory(m_Array + no, m_Array + no + 1, (m_ArrayCnt - no - 1) * sizeof(CBlockParUnit *));
             m_ArrayCnt--;
-            m_Array = (CBlockParUnit **)HAllocClearEx(m_Array, m_ArrayCnt * sizeof(CBlockParUnit *), m_Heap);
+            m_Array = (CBlockParUnit **)HAllocEx(m_Array, m_ArrayCnt * sizeof(CBlockParUnit *), m_Heap);
             return;
         }
         no++;

--- a/MatrixLib/Base/CHeap.cpp
+++ b/MatrixLib/Base/CHeap.cpp
@@ -253,27 +253,4 @@ void CHeap::AllocationError(int zn) {
 #endif
 }
 
-#ifdef MEM_SPY_ENABLE
-void HListPrint(wchar *filename) {
-    char sbuf[1024];
-
-    CBuf buf;
-    buf.SetGranula(1024 * 1024);
-
-    SMemHeader *fb = SMemHeader::first_mem_block;
-    while (fb) {
-        sprintf(sbuf, "%d\t%d\t%d\t%s\t%d\n", DWORD(fb), DWORD(fb) + fb->blocksize - 1, fb->blocksize, fb->file,
-                fb->line);
-
-        buf.BufAdd(sbuf, strlen(sbuf));
-        //        fi.Write(sbuf,strlen(sbuf));
-
-        fb = fb->next;
-    }
-    CFile fi(filename);
-    fi.Create();
-    fi.Write(buf.Get(), buf.Len());
-}
-#endif
-
 }  // namespace Base

--- a/MatrixLib/Base/CHeap.cpp
+++ b/MatrixLib/Base/CHeap.cpp
@@ -225,17 +225,9 @@ CHeap::~CHeap() {
 }
 
 void CHeap::Clear() {
-    if (m_Heap != GetProcessHeap()) {
-        HeapDestroy(m_Heap);
-        m_Heap = GetProcessHeap();
-        if (m_Heap == 0)
-            ERROR_E;
-    }
-    m_Flags = 0;
 }
 
 void CHeap::AllocationError(int zn) {
-    debugbreak();
 #ifdef _DEBUG
     debugbreak();
 #else

--- a/MatrixLib/Base/CHeap.cpp
+++ b/MatrixLib/Base/CHeap.cpp
@@ -164,24 +164,6 @@ void SMemHeader::Release(void) {
     memset(d2, 0, MEM_CHECK_BOUND_SIZE);
 #endif
 }
-void CHeap::Free(void *buf, const char *file, int line) {
-    if (buf == NULL) {
-        CWStr t(L"NULL pointer is passed to Free function at:\n");
-        t += CWStr(CStr(file));
-        t += L" - ";
-        t += line;
-
-        ERROR_S(t.Get());
-    }
-
-#ifdef DEAD_PTR_SPY_ENABLE
-    DeadPtr::free_mem(buf);
-#endif
-
-    SMemHeader *h = SMemHeader::CalcBegin(buf);
-    h->Release();
-    Free(h);
-}
 
 void CHeap::StaticDeInit(void) {
     // check!!!!!!!!!
@@ -211,21 +193,25 @@ void CHeap::StaticDeInit(void) {
     }
 }
 
+void CHeap::Free(void *buf, const char *file, int line) {
+    if (!buf)
+    {
+        ERROR_S(
+            L"NULL pointer is passed to Free function at: " +
+            CWStr(CStr(file)) +
+            L" - " + line);
+    }
+
+#ifdef DEAD_PTR_SPY_ENABLE
+    DeadPtr::free_mem(buf);
 #endif
 
-CHeap::CHeap() : CMain() {
-    m_Flags = 0;
-    m_Heap = GetProcessHeap();
-    if (m_Heap == 0)
-        ERROR_E;
+    SMemHeader *h = SMemHeader::CalcBegin(buf);
+    h->Release();
+    Free(h);
 }
 
-CHeap::~CHeap() {
-    Clear();
-}
-
-void CHeap::Clear() {
-}
+#endif
 
 void CHeap::AllocationError(int zn) {
 #ifdef _DEBUG

--- a/MatrixLib/Base/CHeap.hpp
+++ b/MatrixLib/Base/CHeap.hpp
@@ -7,7 +7,6 @@
 
 #include "CMain.hpp"
 #include "Tracer.hpp"
-//#include "DebugMsg.h"
 
 #if (defined _DEBUG) || (defined FORCE_ENABLE_MEM_SPY)
 #define MEM_SPY_ENABLE
@@ -113,14 +112,7 @@ struct SMemHeader {
 
         if (sz > maxblocksize) {
             maxblocksize = sz;
-            // DbgShowDword("maxblock",sz);
         }
-        // if (sz == 672)
-        //{
-        //    static int c = 0;
-        //    cnt = c++;
-        //    if (cnt == -1) _asm int 3
-        //}
 
         void *ptr;
 #ifdef MEM_CHECK
@@ -138,24 +130,6 @@ struct SMemHeader {
 };
 
 #endif
-
-__inline int CheckValidPtr(const void *ptr) {
-    SYSTEM_INFO si;
-    MEMORY_BASIC_INFORMATION mbi;
-
-    GetSystemInfo(&si);
-
-    if (((uintptr_t)ptr) < ((uintptr_t)si.lpMinimumApplicationAddress))
-        return -1;
-    if (((uintptr_t)ptr) > ((uintptr_t)si.lpMaximumApplicationAddress))
-        return -1;
-
-    VirtualQuery(ptr, &mbi, sizeof(mbi));
-    if (mbi.State == MEM_FREE)
-        return -1;
-
-    return 0;
-}
 
 class BASE_API CHeap : public CMain {
 public:
@@ -360,10 +334,6 @@ namespace Base {
 #define HAllocClearEx(buf, size, heap) CHeap::AllocClearEx((buf), (size))
 #define HFree(buf, heap)               CHeap::Free((buf))
 
-#endif
-
-#ifdef _DEBUG
-void HListPrint(wchar *filename);
 #endif
 
 }  // namespace Base

--- a/MatrixLib/Base/CHeap.hpp
+++ b/MatrixLib/Base/CHeap.hpp
@@ -145,9 +145,9 @@ __inline int CheckValidPtr(const void *ptr) {
 
     GetSystemInfo(&si);
 
-    if (((dword)ptr) < ((dword)si.lpMinimumApplicationAddress))
+    if (((uintptr_t)ptr) < ((uintptr_t)si.lpMinimumApplicationAddress))
         return -1;
-    if (((dword)ptr) > ((dword)si.lpMaximumApplicationAddress))
+    if (((uintptr_t)ptr) > ((uintptr_t)si.lpMaximumApplicationAddress))
         return -1;
 
     VirtualQuery(ptr, &mbi, sizeof(mbi));

--- a/MatrixLib/Base/CHeap.hpp
+++ b/MatrixLib/Base/CHeap.hpp
@@ -230,33 +230,18 @@ inline void *CHeap::ReAllocClear(void *buf, uint size, const char *file, int lin
     return h->Init(sz, file, line);
 }
 
-//#include <stdio.h>
-
 inline void *CHeap::AllocEx(void *buf, uint size, const char *file, int line) {
     DTRACE();
-
-    // char bb[128];
-    // sprintf(bb, "Req: %i, ", size);
-
     SMemHeader *h = NULL;
     if (buf != NULL) {
         h = SMemHeader::CalcBegin(buf);
-
-        // sprintf(bb + strlen(bb), "Before %i, ", h->blocksize);
-
         h->Release();
-    }
-    else {
-        // strcat(bb, "Before NULL, ");
     }
     uint sz = SMemHeader::CalcSize(size);
     h = (SMemHeader *)AllocEx(h, sz);
-
-    // sprintf(bb + strlen(bb), "After %i", sz);
-    // DM("MEM", bb);
-
     return h->Init(sz, file, line);
 }
+
 inline void *CHeap::AllocClearEx(void *buf, uint size, const char *file, int line) {
     DTRACE();
     SMemHeader *h = NULL;
@@ -407,9 +392,6 @@ inline void CHeap::Free(void *buf) {
 
 }  // namespace Base
 
-//inline void * operator new (size_t size) { return Base::Alloc(size,NULL); }
-//inline void operator delete (void * buf) { Base::Free(buf,NULL); }
-
 // lint -e1532
 #ifdef MEM_SPY_ENABLE
 inline BASE_API void *operator new(size_t size, const char *file, int line, Base::CHeap *heap) {
@@ -467,13 +449,5 @@ namespace Base {
 #ifdef _DEBUG
 void HListPrint(wchar *filename);
 #endif
-
-inline bool MemCmp(const void *s1, const void *s2, uint len) {
-    return memcmp(s1, s2, len) == 0;
-}
-
-inline bool MemCmp(const wchar_t *s1, const wchar_t *s2, uint len) {
-    return memcmp(s1, s2, len * sizeof(wchar_t)) == 0;
-}
 
 }  // namespace Base

--- a/MatrixLib/Base/CWStr.cpp
+++ b/MatrixLib/Base/CWStr.cpp
@@ -5,6 +5,8 @@
 
 #include "Base.pch"
 
+#include <cwchar>
+
 #include "CWStr.hpp"
 #include "CException.hpp"
 #include "CStr.hpp"
@@ -753,7 +755,7 @@ bool CWStr::Equal(const wchar *zn, int len) const {
         return false;
     if (len <= 0)
         return true;
-    return MemCmp(Get(), zn, len);
+    return !std::wmemcmp(Get(), zn, len);
 }
 
 bool CWStr::CompareFirst(const CWStr &str) const {

--- a/MatrixLib/Base/CWStrFormat.cpp
+++ b/MatrixLib/Base/CWStrFormat.cpp
@@ -6,6 +6,8 @@
 #include "Base.pch"
 
 #include <stdlib.h>
+#include <cwchar>
+
 #include "CWStr.hpp"
 #include "CStr.hpp"
 #include "CException.hpp"
@@ -284,13 +286,13 @@ CWStr &CWStr::Format(const wchar *format, ...) {
             else if (t_len >= 3 && *format == 'f' && *(format + 1) == '=') {
                 t_fill = ff_GetInt(format + 2, t_len - 2);
             }
-            else if (t_len >= 3 && MemCmp(format, L"a=[", 3)) {
+            else if (t_len >= 3 && !std::wmemcmp(format, L"a=[", 3)) {
                 t_aling = -1;
             }
-            else if (t_len >= 3 && MemCmp(format, L"a=-", 3)) {
+            else if (t_len >= 3 && !std::wmemcmp(format, L"a=-", 3)) {
                 t_aling = 0;
             }
-            else if (t_len >= 3 && MemCmp(format, L"a=]", 3)) {
+            else if (t_len >= 3 && !std::wmemcmp(format, L"a=]", 3)) {
                 t_aling = 1;
             }
             else if (t_len >= 3 && *format == 'p' && *(format + 1) == '=') {

--- a/MatrixLib/Base/Registry.cpp
+++ b/MatrixLib/Base/Registry.cpp
@@ -5,6 +5,8 @@
 
 #include "Base.pch"
 
+#include <cwchar>
+
 #include "CWStr.hpp"
 #include "CException.hpp"
 #include "CStr.hpp"
@@ -14,15 +16,15 @@ namespace Base {
 
 HKEY Reg_OpenKey(HKEY key, const wchar *path, dword access) {
     int len = WStrLen(path);
-    if (len > 5 && MemCmp(path, L"HKCR\\", 5)) {
+    if (len > 5 && !std::wmemcmp(path, L"HKCR\\", 5)) {
         key = HKEY_CLASSES_ROOT;
         path += 5;
     }
-    else if (len > 5 && MemCmp(path, L"HKCU\\", 5)) {
+    else if (len > 5 && !std::wmemcmp(path, L"HKCU\\", 5)) {
         key = HKEY_CURRENT_USER;
         path += 5;
     }
-    else if (len > 5 && MemCmp(path, L"HKLM\\", 5)) {
+    else if (len > 5 && !std::wmemcmp(path, L"HKLM\\", 5)) {
         key = HKEY_LOCAL_MACHINE;
         path += 5;
     }
@@ -42,15 +44,15 @@ HKEY Reg_OpenKey(HKEY key, const wchar *path, dword access) {
 
 HKEY Reg_CreateKey(HKEY key, const wchar *path, dword access) {
     int len = WStrLen(path);
-    if (len > 5 && MemCmp(path, L"HKCR\\", 5)) {
+    if (len > 5 && !std::wmemcmp(path, L"HKCR\\", 5)) {
         key = HKEY_CLASSES_ROOT;
         path += 5;
     }
-    else if (len > 5 && MemCmp(path, L"HKCU\\", 5)) {
+    else if (len > 5 && !std::wmemcmp(path, L"HKCU\\", 5)) {
         key = HKEY_CURRENT_USER;
         path += 5;
     }
-    else if (len > 5 && MemCmp(path, L"HKLM\\", 5)) {
+    else if (len > 5 && !std::wmemcmp(path, L"HKLM\\", 5)) {
         key = HKEY_LOCAL_MACHINE;
         path += 5;
     }

--- a/MatrixLib/DebugMsg/Command.cpp
+++ b/MatrixLib/DebugMsg/Command.cpp
@@ -138,7 +138,7 @@ public:
 public:
     CDCommand(void *buf) {
         m_BufSize = *(int *)((char *)(buf) + 8);
-        m_Buf = (char *)HeapAlloc(GetProcessHeap(), 0, m_BufSize);
+        m_Buf = (char *)malloc(m_BufSize);
         CopyMemory(m_Buf, buf, m_BufSize);
         m_NameW = (wchar_t *)((m_Buf) + (*(int *)((m_Buf) + 16)));
         m_NameA = (char *)((m_Buf) + (*(int *)((m_Buf) + 16 + 4)));
@@ -153,11 +153,11 @@ public:
     }
     ~CDCommand() {
         if (m_Buf != NULL) {
-            HeapFree(GetProcessHeap(), 0, m_Buf);
+            free(m_Buf);
             m_Buf = NULL;
         }
         if (m_ABuf != NULL) {
-            HeapFree(GetProcessHeap(), 0, m_ABuf);
+            free(m_ABuf);
             m_ABuf = NULL;
         }
     }
@@ -230,12 +230,12 @@ public:
     }
     void AnswerTest(int size) {
         if (m_ABuf == NULL) {
-            m_ABuf = (char *)HeapAlloc(GetProcessHeap(), 0, size);
+            m_ABuf = (char*)malloc(size);
             m_ABufSizeMax = size;
         }
         else if (m_ABufSizeMax < (m_ABufSize + size)) {
             m_ABufSizeMax = m_ABufSize + size + 1024;
-            m_ABuf = (char *)HeapReAlloc(GetProcessHeap(), 0, m_ABuf, m_ABufSizeMax);
+            m_ABuf = (char*)realloc(m_ABuf, m_ABufSizeMax);
         }
     }
     void Answer(wchar_t *str, int strsize) {


### PR DESCRIPTION
This MR removes windows-like memory management calls (e.g. HeapAlloc, HeapFree) and replaces them with a standard malloc, free, etc.
CHeap class still exists, but having no internal state it just provides a stupid wrapper interface around native calls (not that stupid in debug mode, but nevertheless), so could be ignored and replaced with C++-style new/delete calls or usage of standard containers, smart pointers and other stuff.