### PR TITLE
allow and use C++20

### DIFF
--- a/.github/workflows/win-build.yml
+++ b/.github/workflows/win-build.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Auto-build
 
 on:
   push:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CONFIGURATION_TYPES Release Debug)
 
 project(MatrixGame)
@@ -38,6 +38,11 @@ if(MSVC)
     )
 
     list(APPEND COMPILE_DEFINITIONS $<$<CONFIG:Release>:_CRT_SECURE_NO_WARNINGS> _AFX_NO_DEBUG_CRT)
+
+    # TODO: <codecvt> is deprecated since C++17. in future we should
+    # use std::string everywhere and not cast string <-> wstring.
+    # till then - here is a hotfix to suppress warnings
+    list(APPEND COMPILE_DEFINITIONS _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING)
 else()
     list(APPEND COMPILE_DEFINITIONS $<$<CONFIG:Debug>:_DEBUG>)
 

--- a/MatrixLib/Base/Tracer.cpp
+++ b/MatrixLib/Base/Tracer.cpp
@@ -352,7 +352,7 @@ CDebugTracer ::CDebugTracer(const char *src_file, int src_line, bool cp) throw()
 
 CDebugTracer::~CDebugTracer() throw() {
 #ifdef HISTORY_PATH_ONLY
-    if (!std::uncaught_exception()) {
+    if (!std::uncaught_exceptions()) {
         DelLastHistory();
     }
 #endif

--- a/README.md
+++ b/README.md
@@ -28,18 +28,18 @@ There are different possibilities to build the project, just chose the one you l
 ### Historical way (does not work anymore)
 Original sources pack included Visual Studio 2010 project/solution files and was intended to be built using VS2010-2012 (in fact, any newer version should work too).<br>
 Base repo (the one this was forked from) added a CMake files and changed a code folders structure to improve and simplify a build process.<br>
-After refactoring done in this repo (which made the code C++11 compliant) versions before 2015 most probably will not work anymore, so we're coming to...
+After refactoring done in this repo (which brought modern C++ standards support) versions before VS17 2022 might not work anymore, so we're coming to...
 
 ### Canonical way (for now)
-MS Visual Studio 2015 or newer is required, together with dependencies described above. Put your version to -G argument or remove it so CMake will use default one.
+MS Visual Studio 17 2022 or newer is required, together with dependencies described above. Put your version to -G argument or remove it so CMake will use default one.
 
-    cmake -A Win32 -G "Visual Studio 2015" -B ./build ..
+    cmake -A Win32 -G "Visual Studio 17 2022" -B ./build ..
     cmake --build ./build
 
 See what's happening, check the final binary path at the end and find your game file.
 
-### Alternative way (future canonical)
-The main purpose of C++11-conformity update was to make the project buildable with GCC. It opens a door to C++17/20 and even future revisions.<br>
+### Alternative way (maybe future canonical)
+The main purpose of of the first refactoring steps was to make the project buildable with GCC.<br>
 To go this way you have to [download a GCC build](https://winlibs.com/) (most recent one is recommended; also remember you need 32-bit build), unpack it and add the _bin_ directory path into your PATH environment variable.<br>
 Also I strongly recommend to use [Ninja build system](https://ninja-build.org/) instead of MinGW native mingw32-make, 'cause building with the latter is __extremely__ slow. Add it to your PATH too, or just copy to a mingw _bin_ folder - it's just a single small executable.<br>
 After preparing your env you can use CMake to do the work for you:
@@ -48,7 +48,7 @@ After preparing your env you can use CMake to do the work for you:
     cmake --build ./build
 
 Anyway I personally prefer exactly this option 'cause it's much easier to update it (download about 100MB zip and unpack versus installing few gigabytes of MSVS software bundle, which includes tons of tools I've never asked for), it always provides the most recent implementation of C++ libs and features (even ones that on TS stage and not released yet) and it includes the DirectX libs, so you don't even have to bother about dependencies. The only disadvantage of this option comparing to MSVC - Visual Studio provides a fancy debugging environment which GDB could never replace. But there is a solution - do not introduce any bugs, and you'll not have to debug ;)<br>
-This way will become a new canonical soon - once I sure both project and myself are ready for it.
+This way most probably will become a new canonical once.
 
 ## Testing
 There are no unit-tests, and in fact no any other sort of tests. In general to test the game - play it! If it runs - that's already a good sign. If it works and does not crash - perfect, it's not broken. If you're too lazy even to play - build the game with cheats enabled and use _AUTO_ cheat for game to play itself. Just keep an eye on it and feel free to call it "self-testing" ;)<br>


### PR DESCRIPTION
This MR enables C++20 support in the repo. Use any modern C++ features you'd like until it compiles with both GCC and MSVC and works (maybe except modules ;)).
Since now building with MSVC will obvioulsy require one of the latest releases, legacy versions like 2015 ain't supported anymore.