### PR TITLE
CBuf to std::vector

### DIFF
--- a/MatrixGame/src/Effects/MatrixEffectPointLight.cpp
+++ b/MatrixGame/src/Effects/MatrixEffectPointLight.cpp
@@ -167,7 +167,7 @@ void CMatrixEffectPointLight::Clear(void) {
     // if(IS_IB(m_IB)) { DESTROY_IB(m_IB); }
 
     RemoveColorData();
-    m_PointLum.Clear();
+    m_PointLum.clear();
     // m_StripsCnt=0;
 }
 
@@ -230,7 +230,7 @@ void CMatrixEffectPointLight::BuildLand(void) {
         if (v->mp != NULL) {                       \
             light.lum = v->lum;                    \
             light.mp = v->mp;                      \
-            m_PointLum.Add<SMapPointLight>(light); \
+            m_PointLum.push_back(light);           \
         }                                          \
         ++verts;                                   \
         ++m_NumVerts;                              \
@@ -426,7 +426,7 @@ void CMatrixEffectPointLight::BuildLandV(void) {
         if (v->mp != NULL) {                                         \
             light.lum = v->lum;                                      \
             light.mp = v->mp;                                        \
-            m_PointLum.Add<SMapPointLight>(light);                   \
+            m_PointLum.push_back(light);                             \
         }                                                            \
         ++verts;                                                     \
         ++m_NumVerts;                                                \
@@ -618,36 +618,37 @@ void CMatrixEffectPointLight::UpdateData(void) {
     g_MatrixMap->MarkNeedRecalcTerainColor();
 }
 
-void CMatrixEffectPointLight::RemoveColorData(void) {
-    if (m_PointLum.Len() == 0)
+void CMatrixEffectPointLight::RemoveColorData(void)
+{
+    if (m_PointLum.empty())
+    {
         return;
-    SMapPointLight *mp = m_PointLum.Buff<SMapPointLight>();
-    SMapPointLight *mp_end = m_PointLum.BuffEnd<SMapPointLight>();
+    }
 
-    while (mp < mp_end) {
-        mp->mp->lum_r -= mp->addlum_r;
-        mp->mp->lum_g -= mp->addlum_g;
-        mp->mp->lum_b -= mp->addlum_b;
-
-        ++mp;
+    for (auto& item : m_PointLum)
+    {
+        item.mp->lum_r -= item.addlum_r;
+        item.mp->lum_g -= item.addlum_g;
+        item.mp->lum_b -= item.addlum_b;
     }
 }
 
-void CMatrixEffectPointLight::AddColorData(void) {
-    if (m_PointLum.Len() == 0)
+void CMatrixEffectPointLight::AddColorData(void)
+{
+    if (m_PointLum.empty())
+    {
         return;
-    SMapPointLight *mp = m_PointLum.Buff<SMapPointLight>();
-    SMapPointLight *mp_end = m_PointLum.BuffEnd<SMapPointLight>();
+    }
 
-    while (mp < mp_end) {
-        mp->addlum_r = Float2Int(mp->lum * float((m_Color >> 16) & 255));
-        mp->addlum_g = Float2Int(mp->lum * float((m_Color >> 8) & 255));
-        mp->addlum_b = Float2Int(mp->lum * float((m_Color >> 0) & 255));
+    for (auto& item : m_PointLum)
+    {
+        item.addlum_r = Float2Int(item.lum * float((m_Color >> 16) & 255));
+        item.addlum_g = Float2Int(item.lum * float((m_Color >> 8) & 255));
+        item.addlum_b = Float2Int(item.lum * float((m_Color >> 0) & 255));
 
-        mp->mp->lum_r += mp->addlum_r;
-        mp->mp->lum_g += mp->addlum_g;
-        mp->mp->lum_b += mp->addlum_b;
-        ++mp;
+        item.mp->lum_r += item.addlum_r;
+        item.mp->lum_g += item.addlum_g;
+        item.mp->lum_b += item.addlum_b;
     }
 
     g_MatrixMap->MarkNeedRecalcTerainColor();

--- a/MatrixGame/src/Effects/MatrixEffectPointLight.hpp
+++ b/MatrixGame/src/Effects/MatrixEffectPointLight.hpp
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <vector>
+
 // point light
 #define POINTLIGHT_FVF   (D3DFVF_XYZ | D3DFVF_DIFFUSE | D3DFVF_TEX2)
 #define POINTLIGHT_FVF_V (D3DFVF_XYZ | D3DFVF_DIFFUSE)
@@ -128,7 +130,7 @@ class CMatrixEffectPointLight : public CMatrixEffect {
 
     CBillboard *m_Bill;
 
-    CBuf m_PointLum;
+    std::vector<SMapPointLight> m_PointLum;
 
     CMatrixEffectPointLight(const D3DXVECTOR3 &pos, float r, DWORD color, bool drawbill = false);
     virtual ~CMatrixEffectPointLight();

--- a/MatrixGame/src/Interface/MatrixHint.cpp
+++ b/MatrixGame/src/Interface/MatrixHint.cpp
@@ -12,6 +12,8 @@
 
 #include "CFile.hpp"
 
+#include <vector>
+
 CMatrixHint *CMatrixHint::m_First;
 CMatrixHint *CMatrixHint::m_Last;
 
@@ -42,7 +44,7 @@ CMatrixHint *CMatrixHint::Build(int border, const std::wstring &soundin, const s
     int cw = 0;
     int ch = 0;
 
-    CBuf pos;
+    std::vector<CPoint> pos;
 
     bool new_coord_f = false;
     CPoint new_coord;
@@ -58,11 +60,11 @@ CMatrixHint *CMatrixHint::Build(int border, const std::wstring &soundin, const s
 
         if (els->hem == HEM_BITMAP) {
             if (new_coord_f) {
-                pos.Add<CPoint>(new_coord);
+                pos.push_back(new_coord);
                 new_coord_f = false;
             }
             else {
-                pos.Add<CPoint>(CPoint(cx, cy));
+                pos.push_back(CPoint(cx, cy));
                 cx += bx;
                 if (cx > cw)
                     cw = cx;
@@ -71,7 +73,7 @@ CMatrixHint *CMatrixHint::Build(int border, const std::wstring &soundin, const s
             }
         }
         else if (els->hem == HEM_LAST_ON_LINE) {
-            pos.Add<CPoint>(CPoint(cx, cy));
+            pos.push_back(CPoint(cx, cy));
             cx += bx;
             if (cx > cw)
                 cw = cx;
@@ -81,7 +83,7 @@ CMatrixHint *CMatrixHint::Build(int border, const std::wstring &soundin, const s
             cy = ch;
         }
         else if (els->hem == HEM_LAST) {
-            pos.Add<CPoint>(CPoint(cx, cy));
+            pos.push_back(CPoint(cx, cy));
             cx += bx;
             if (cx > cw)
                 cw = cx;
@@ -90,7 +92,7 @@ CMatrixHint *CMatrixHint::Build(int border, const std::wstring &soundin, const s
             break;
         }
         else if (els->hem == HEM_CENTER) {
-            pos.Add<CPoint>(CPoint(-1000, cy));
+            pos.push_back(CPoint(-1000, cy));
             if (bx > cw)
                 cw = bx;
             if ((cy + by) > ch)
@@ -99,7 +101,7 @@ CMatrixHint *CMatrixHint::Build(int border, const std::wstring &soundin, const s
             cy = ch;
         }
         else if (els->hem <= HEM_TAB_LARGEST) {
-            pos.Add<CPoint>(CPoint(els->hem, cy));
+            pos.push_back(CPoint(els->hem, cy));
             cx = els->hem + bx;
             if (cx > cw)
                 cw = cx;
@@ -107,7 +109,7 @@ CMatrixHint *CMatrixHint::Build(int border, const std::wstring &soundin, const s
                 ch = by + cy;
         }
         else if (els->hem <= HEM_CENTER_RIGHT_LARGEST) {
-            pos.Add<CPoint>(CPoint(-1001, cy));
+            pos.push_back(CPoint(-1001, cy));
 
             int tv = els->hem - HEM_TAB_LARGEST;
             if ((tv + bx) > (cw / 2))
@@ -117,7 +119,7 @@ CMatrixHint *CMatrixHint::Build(int border, const std::wstring &soundin, const s
                 ch = by + cy;
         }
         else if (els->hem <= HEM_CENTER_LEFT_LARGEST) {
-            pos.Add<CPoint>(CPoint(-1002, cy));
+            pos.push_back(CPoint(-1002, cy));
 
             int tv = els->hem - HEM_CENTER_RIGHT_LARGEST;
             if ((tv + bx) > (cw / 2))
@@ -127,18 +129,18 @@ CMatrixHint *CMatrixHint::Build(int border, const std::wstring &soundin, const s
                 ch = by + cy;
         }
         else if (els->hem == HEM_COPY) {
-            pos.Add<CPoint>(CPoint(0, 0));
+            pos.push_back(CPoint(0, 0));
             // do nothing
         }
         else if (els->hem == HEM_DOWN) {
-            pos.Add<CPoint>(CPoint(0, 0));
+            pos.push_back(CPoint(0, 0));
             cy += els->y;
             if (cy > ch)
                 ch = cy;
             els->bmp = NULL;
         }
         else if (els->hem == HEM_RIGHT) {
-            pos.Add<CPoint>(CPoint(0, 0));
+            pos.push_back(CPoint(0, 0));
             cx += els->x;
             if (cx > cw)
                 cw = cx;
@@ -148,7 +150,7 @@ CMatrixHint *CMatrixHint::Build(int border, const std::wstring &soundin, const s
             new_coord_f = true;
             new_coord.x = els->x;
             new_coord.y = els->y;
-            pos.Add<CPoint>(CPoint(0, 0));
+            pos.push_back(CPoint(0, 0));
             els->bmp = NULL;
             // do nothing
         }
@@ -262,24 +264,25 @@ CMatrixHint *CMatrixHint::Build(int border, const std::wstring &soundin, const s
         h_delta = parts[4].size.y;
     }
 
-    CPoint *pb = pos.Buff<CPoint>();
-    CPoint *pe = pos.BuffEnd<CPoint>();
     int idx = 0;
-    for (; pb < pe; ++pb, ++idx) {
-        if (pb->x == -1000) {
-            pb->x = (cw - elems[idx].bmp->SizeX()) / 2;
+    for (auto& item : pos)
+    {
+        if (item.x == -1000) {
+            item.x = (cw - elems[idx].bmp->SizeX()) / 2;
         }
-        else if (pb->x == -1001) {
+        else if (item.x == -1001) {
             int tv = elems[idx].hem - HEM_TAB_LARGEST;
-            pb->x = cw / 2 + tv;
+            item.x = cw / 2 + tv;
         }
-        else if (pb->x == -1002) {
+        else if (item.x == -1002) {
             int tv = elems[idx].hem - HEM_CENTER_RIGHT_LARGEST;
-            pb->x = cw / 2 - tv - elems[idx].bmp->SizeX();
+            item.x = cw / 2 - tv - elems[idx].bmp->SizeX();
         }
 
-        pb->x += ots.left;
-        pb->y += ots.top;
+        item.x += ots.left;
+        item.y += ots.top;
+
+        ++idx;
     }
 
     if (ch < (parts[1].size.y + parts[7].size.y - ots.top - ots.bottom)) {
@@ -365,32 +368,32 @@ CMatrixHint *CMatrixHint::Build(int border, const std::wstring &soundin, const s
     CPoint *copypos = NULL;
     int copyposcnt = 0;
 
-    pb = pos.Buff<CPoint>();
-    pe = pos.BuffEnd<CPoint>();
     idx = 0;
     bool copy = false;
-    for (; pb < pe; ++pb, ++idx) {
+    for (const auto& item : pos)
+    {
         bool new_copy = elems[idx].hem == HEM_COPY;
 
         if (elems[idx].bmp) {
             if (copy) {
-                bmpf.Copy(*pb, elems[idx].bmp->Size(), *elems[idx].bmp, CPoint(0, 0));
+                bmpf.Copy(item, elems[idx].bmp->Size(), *elems[idx].bmp, CPoint(0, 0));
 
                 ++copyposcnt;
                 copypos = (CPoint *)HAllocEx(copypos, sizeof(CPoint) * copyposcnt, g_MatrixHeap);
-                copypos[copyposcnt - 1] = *pb;
+                copypos[copyposcnt - 1] = item;
             }
             else {
                 if (elems[idx].bmp->BytePP() == 3) {
-                    bmpf.Copy(*pb, elems[idx].bmp->Size(), *elems[idx].bmp, CPoint(0, 0));
+                    bmpf.Copy(item, elems[idx].bmp->Size(), *elems[idx].bmp, CPoint(0, 0));
                 }
                 else {
-                    bmpf.MergeWithAlpha(*pb, elems[idx].bmp->Size(), *elems[idx].bmp, CPoint(0, 0));
+                    bmpf.MergeWithAlpha(item, elems[idx].bmp->Size(), *elems[idx].bmp, CPoint(0, 0));
                 }
             }
         }
 
         copy = new_copy;
+        ++idx;
     }
 
     // bmpf.SaveInPNG(L"bla.png");

--- a/MatrixGame/src/MatrixFormGame.cpp
+++ b/MatrixGame/src/MatrixFormGame.cpp
@@ -1042,7 +1042,7 @@ void CFormMatrixGame::Keyboard(bool down, int scan) {
     }
 
     if (scan == KEY_ENTER && down) {
-        if (g_MatrixMap->m_DialogModeName && (g_MatrixMap->m_DialogModeHints.Len() > 4 ||
+        if (g_MatrixMap->m_DialogModeName && (g_MatrixMap->m_DialogModeHints.size() > 1 ||
                                               wcscmp(g_MatrixMap->m_DialogModeName, TEMPLATE_DIALOG_MENU) != 0)) {
             g_IFaceList->PressHintButton(HINT_OK);
             return;
@@ -1051,7 +1051,7 @@ void CFormMatrixGame::Keyboard(bool down, int scan) {
 
     if (scan == KEY_E && down) {
         if (g_MatrixMap->m_DialogModeName && wcscmp(g_MatrixMap->m_DialogModeName, TEMPLATE_DIALOG_MENU) == 0) {
-            if (g_MatrixMap->m_DialogModeHints.Len() > 4) {}
+            if (g_MatrixMap->m_DialogModeHints.size() > 1) {}
             else {
                 ExitRequestHandler();
                 return;
@@ -1060,7 +1060,7 @@ void CFormMatrixGame::Keyboard(bool down, int scan) {
     }
     if (scan == KEY_S && down) {
         if (g_MatrixMap->m_DialogModeName && wcscmp(g_MatrixMap->m_DialogModeName, TEMPLATE_DIALOG_MENU) == 0) {
-            if (g_MatrixMap->m_DialogModeHints.Len() > 4) {}
+            if (g_MatrixMap->m_DialogModeHints.size() > 1) {}
             else {
                 SurrenderRequestHandler();
                 return;
@@ -1069,7 +1069,7 @@ void CFormMatrixGame::Keyboard(bool down, int scan) {
     }
     if (scan == KEY_R && down) {
         if (g_MatrixMap->m_DialogModeName && wcscmp(g_MatrixMap->m_DialogModeName, TEMPLATE_DIALOG_MENU) == 0) {
-            if (g_MatrixMap->m_DialogModeHints.Len() > 4) {}
+            if (g_MatrixMap->m_DialogModeHints.size() > 1) {}
             else {
                 ResetRequestHandler();
                 return;
@@ -1086,7 +1086,7 @@ void CFormMatrixGame::Keyboard(bool down, int scan) {
         }
 
         if (g_MatrixMap->m_DialogModeName && wcscmp(g_MatrixMap->m_DialogModeName, TEMPLATE_DIALOG_MENU) == 0) {
-            if (g_MatrixMap->m_DialogModeHints.Len() > 4) {
+            if (g_MatrixMap->m_DialogModeHints.size() > 1) {
                 ConfirmCancelHandler();
             }
             else {

--- a/MatrixGame/src/MatrixMap.cpp
+++ b/MatrixGame/src/MatrixMap.cpp
@@ -818,8 +818,9 @@ bool CMatrixMap::UnitPickWorld(const D3DXVECTOR3 &orig, const D3DXVECTOR3 &dir, 
 void CMatrixMap::StaticClear(void) {
     DTRACE();
 
-    for (; m_AllObjects.Len() > 0;) {
-        StaticDelete(*m_AllObjects.Buff<CMatrixMapStatic *>());
+    while (!m_AllObjects.empty())
+    {
+        StaticDelete(m_AllObjects.front());
     }
 
     CMatrixMapObject::ClearTextures();
@@ -842,9 +843,9 @@ void CMatrixMap::StaticDelete(CMatrixMapStatic *ms) {
 
     CMatrixMapStatic::RemoveFromSorted(ms);
 
-    CMatrixMapStatic **sb = m_AllObjects.Buff<CMatrixMapStatic *>();
-    CMatrixMapStatic **se = m_AllObjects.BuffEnd<CMatrixMapStatic *>();
-    CMatrixMapStatic **ses = se - 1;
+    auto sb = m_AllObjects.begin();
+    auto se = m_AllObjects.end();
+    auto ses = se - 1;
 
     if (ms->InLT()) {
         ms->DelLT();
@@ -865,7 +866,7 @@ void CMatrixMap::StaticDelete(CMatrixMapStatic *ms) {
             ++sb;
         }
     }
-    m_AllObjects.SetLenNoShrink(m_AllObjects.Len() - sizeof(CMatrixMapStatic *));
+    m_AllObjects.erase(m_AllObjects.end() - 1);
 
     //#ifdef _DEBUG
     //    std::wstring c(L"Del obj ");
@@ -922,9 +923,7 @@ void CMatrixMap::StaticDelete(CMatrixMapStatic *ms) {
 ////    SLOG("objlog.txt", c.Get());
 ////#endif
 //
-//    m_AllObjects.Expand(sizeof(CMatrixMapStatic *));
-//    CMatrixMapStatic ** e = m_AllObjects.BuffEnd<CMatrixMapStatic *>();
-//    *(e-1) = ms;
+//    m_AllObjects.push_back(ms);
 //
 //
 //	if(add_to_logic && type!=OBJECT_TYPE_MAPOBJECT)
@@ -3435,12 +3434,12 @@ void CMatrixMap::ShowPortrets(void) {
     int n = 0;
     SETFLAG(g_MatrixMap->m_Flags, MMFLAG_SHOWPORTRETS);
 
-    CMatrixMapStatic **sb = m_AllObjects.Buff<CMatrixMapStatic *>();
-    CMatrixMapStatic **se = m_AllObjects.BuffEnd<CMatrixMapStatic *>();
-    for (; sb < se; ++sb) {
-        if ((*sb)->GetObjectType() == OBJECT_TYPE_MAPOBJECT && ((CMatrixMapObject *)(*sb))->m_BehFlag == BEHF_PORTRET) {
-            ((CMatrixMapObject *)(*sb))->m_PrevStateRobotsInRadius = ++n;
-            ((CMatrixMapObject *)(*sb))->RChange(MR_Graph);
+    for (auto item : m_AllObjects)
+    {
+        if (item->GetObjectType() == OBJECT_TYPE_MAPOBJECT && ((CMatrixMapObject*)item)->m_BehFlag == BEHF_PORTRET)
+        {
+            ((CMatrixMapObject*)item)->m_PrevStateRobotsInRadius = ++n;
+            ((CMatrixMapObject*)item)->RChange(MR_Graph);
         }
     }
 }

--- a/MatrixGame/src/MatrixMap.cpp
+++ b/MatrixGame/src/MatrixMap.cpp
@@ -76,7 +76,6 @@ CMatrixMap::CMatrixMap()
     D3DXVec3Normalize(&m_LightMain, &m_LightMain);
 
     m_Water = NULL;
-    m_VisWater = NULL;
     m_VisibleGroupsCount = 0;
 
     m_IdsCnt = 0;
@@ -1036,10 +1035,8 @@ void CMatrixMap::WaterClear() {
         HDelete(CMatrixWater, m_Water, g_MatrixHeap);
         m_Water = NULL;
     }
-    if (m_VisWater) {
-        HDelete(CBuf, m_VisWater, g_MatrixHeap);
-        m_VisWater = NULL;
-    }
+    m_VisWater.clear();
+
     SInshorewave::MarkAllBuffersNoNeed();
 }
 
@@ -1052,12 +1049,8 @@ void CMatrixMap::WaterInit() {
     else {
         m_Water->Clear();
     }
-    if (!m_VisWater) {
-        m_VisWater = HNew(g_MatrixHeap) CBuf();
-    }
-    else {
-        m_VisWater->Clear();
-    }
+
+    m_VisWater.clear();
     m_Water->Init();
 }
 
@@ -1712,16 +1705,11 @@ void CMatrixMap::DrawWater(void) {
     for (curpass = 0; curpass < g_Render->m_WaterPassSolid; ++curpass) {
         g_Render->m_WaterSolid(m_Water->m_WaterTex1, m_Water->m_WaterTex2, curpass);
 
-        D3DXVECTOR2 *bp = m_VisWater->Buff<D3DXVECTOR2>();
-        D3DXVECTOR2 *ep = m_VisWater->BuffEnd<D3DXVECTOR2>();
-
-        while (bp < ep) {
-            // m_VisWater->BufGet(&p,sizeof(D3DXVECTOR2));
-            m._41 = bp->x;
-            m._42 = bp->y;
+        for (const auto& item : m_VisWater)
+        {
+            m._41 = item.x;
+            m._42 = item.y;
             m_Water->Draw(m);
-
-            ++bp;
         }
     }
 

--- a/MatrixGame/src/MatrixMap.cpp
+++ b/MatrixGame/src/MatrixMap.cpp
@@ -2386,7 +2386,7 @@ void CMatrixMap::Draw(void) {
 
     if (m_DialogModeName) {
         if (wcscmp(m_DialogModeName, TEMPLATE_DIALOG_MENU) == 0) {
-            m_DialogModeHints.Buff<CMatrixHint *>()[0]->DrawNow();
+            m_DialogModeHints[0]->DrawNow();
         }
     }
 
@@ -3143,18 +3143,18 @@ void CMatrixMap::LeaveDialogMode(void) {
         return;
 
     if (0 == wcscmp(m_DialogModeName, TEMPLATE_DIALOG_MENU)) {
-        m_DialogModeHints.Buff<CMatrixHint *>()[0]->SoundOut();
+        m_DialogModeHints[0]->SoundOut();
     }
 
     RESETFLAG(m_Flags, MMFLAG_DIALOG_MODE);
     Pause(false);
-    DWORD *a = m_DialogModeHints.Buff<DWORD>();
-    DWORD *b = m_DialogModeHints.BuffEnd<DWORD>();
-    for (; a < b; ++a) {
-        ((CMatrixHint *)(*a))->Release();
+
+    for (auto item : m_DialogModeHints)
+    {
+        item->Release();
     }
 
-    m_DialogModeHints.Clear();
+    m_DialogModeHints.clear();
     g_IFaceList->HideHintButtons();
     m_DialogModeName = NULL;
 }
@@ -3205,8 +3205,8 @@ static void OkResetHandler(void) {
     // SETFLAG(g_Flags, GFLAG_EXITLOOP);
 }
 void ConfirmCancelHandler(void) {
-    CMatrixHint *h = (CMatrixHint *)g_MatrixMap->m_DialogModeHints.Buff<DWORD>()[1];
-    g_MatrixMap->m_DialogModeHints.SetLenNoShrink(g_MatrixMap->m_DialogModeHints.Len() - sizeof(DWORD));
+    CMatrixHint *h = (CMatrixHint *)g_MatrixMap->m_DialogModeHints[1];
+    g_MatrixMap->m_DialogModeHints.erase(g_MatrixMap->m_DialogModeHints.end() - 1);
     h->Release();
 
     g_IFaceList->EnableMainMenuButton(HINT_CANCEL_MENU);
@@ -3226,8 +3226,6 @@ static void CreateConfirmation(const wchar *hint, DialogButtonHandler handler) {
     g_IFaceList->DisableMainMenuButton(HINT_RESET);
     g_IFaceList->DisableMainMenuButton(HINT_EXIT);
 
-    g_MatrixMap->m_DialogModeHints.Pointer(g_MatrixMap->m_DialogModeHints.Len());
-
     CMatrixHint *h = CMatrixHint::Build(std::wstring(hint), hint);
     int ww = (g_ScreenX - h->m_Width) / 2;
     int hh = (g_ScreenY - h->m_Height) / 2 - Float2Int(float(g_ScreenY) * 0.09f);
@@ -3244,7 +3242,7 @@ static void CreateConfirmation(const wchar *hint, DialogButtonHandler handler) {
         g_IFaceList->CreateHintButton(x, y, HINT_CANCEL, ConfirmCancelHandler);
     }
 
-    g_MatrixMap->m_DialogModeHints.Add<uint32_t>((DWORD)h);
+    g_MatrixMap->m_DialogModeHints.push_back(h);
 }
 
 void ExitRequestHandler(void) {
@@ -3292,8 +3290,6 @@ void CMatrixMap::EnterDialogMode(const wchar *hint_i) {
     if (0 != wcscmp(hint_i, TEMPLATE_DIALOG_BEGIN)) {
         g_MatrixMap->GetPlayerSide()->PLDropAllActions();
     }
-
-    m_DialogModeHints.Pointer(m_DialogModeHints.Len());
 
     CBlockPar *bp = g_MatrixData->BlockGet(PAR_TEMPLATES);
 
@@ -3392,7 +3388,7 @@ void CMatrixMap::EnterDialogMode(const wchar *hint_i) {
             }
 
             ww += h->m_Width + 20;
-            m_DialogModeHints.Add<uint32_t>((DWORD)h);
+            m_DialogModeHints.push_back(h);
         }
     }
 }

--- a/MatrixGame/src/MatrixMap.hpp
+++ b/MatrixGame/src/MatrixMap.hpp
@@ -11,6 +11,8 @@
 
 #include "CStorage.hpp"
 
+#include <vector>
+
 //#define DRAW_LANDSCAPE_SETKA 1
 
 #define FREE_TIME_PERIOD (5000)  // in ms
@@ -256,7 +258,7 @@ enum {
 class CMatrixHint;
 
 class CMatrixMap : public CMain {
-    CBuf m_AllObjects;
+    std::vector<CMatrixMapStatic*> m_AllObjects;
 
 protected:
     ~CMatrixMap();
@@ -533,9 +535,7 @@ public:
     // CMatrixMapStatic * StaticAdd(EObjectType type, bool add_to_logic = true);
 
     inline void AddObject(CMatrixMapStatic *ms, bool add_to_logic) {
-        m_AllObjects.Expand(sizeof(CMatrixMapStatic *));
-        CMatrixMapStatic **e = m_AllObjects.BuffEnd<CMatrixMapStatic *>();
-        *(e - 1) = ms;
+        m_AllObjects.push_back(ms);
         if (add_to_logic)
             ms->AddLT();
     }

--- a/MatrixGame/src/MatrixMap.hpp
+++ b/MatrixGame/src/MatrixMap.hpp
@@ -286,7 +286,7 @@ public:
 
     CMatrixHint *m_PauseHint;
 
-    CBuf m_DialogModeHints;
+    std::vector<CMatrixHint*> m_DialogModeHints;
     const wchar *m_DialogModeName;
 
     int m_TexUnionDim;

--- a/MatrixGame/src/MatrixMap.hpp
+++ b/MatrixGame/src/MatrixMap.hpp
@@ -412,7 +412,7 @@ protected:
     float m_minz;
     float m_maxz;
 
-    CBuf *m_VisWater;
+    std::vector<D3DXVECTOR2> m_VisWater;
 
     CMatrixMapGroup **m_VisibleGroups;
     int m_VisibleGroupsCount;

--- a/MatrixGame/src/MatrixMap.hpp
+++ b/MatrixGame/src/MatrixMap.hpp
@@ -589,11 +589,11 @@ public:
     // DWORD Load(CBuf & b, CBlockPar & bp, bool &surface_macro);
     void Restart(void);  // boo!
 
-    int ReloadDynamics(CStorage &stor, EReloadStep step, CBuf *robots = NULL);
+    int ReloadDynamics(CStorage &stor, EReloadStep step, void* robots = NULL);
 
     int PrepareMap(CStorage &stor, const std::wstring &mapname);
     void StaticPrepare(int n, bool skip_progress = false);
-    void StaticPrepare2(CBuf *robots);
+    void StaticPrepare2(void* robots);
 
     void InitObjectsLights(void);  // must be called only after CreatePoolDefaultResources
     void ReleasePoolDefaultResources(void);

--- a/MatrixGame/src/MatrixMapPrepare.cpp
+++ b/MatrixGame/src/MatrixMapPrepare.cpp
@@ -1567,27 +1567,25 @@ int CMatrixMap::PrepareMap(CStorage &stor, const std::wstring &mapname) {
 
 void CMatrixMap::StaticPrepare2(CBuf *robots) {
     // prepare shadows textures
-    CMatrixMapStatic **sb = m_AllObjects.Buff<CMatrixMapStatic *>();
-    CMatrixMapStatic **se = m_AllObjects.BuffEnd<CMatrixMapStatic *>();
-    while (sb < se) {
-        if ((*sb)->GetObjectType() == OBJECT_TYPE_MAPOBJECT) {
-            if (((CMatrixMapObject *)(*sb))->m_ShadowType == SHADOW_PROJ_DYNAMIC &&
-                ((CMatrixMapObject *)(*sb))->m_Graph->VO()->GetFramesCnt() > 1) {}
+    for (auto item : m_AllObjects)
+    {
+        if (item->GetObjectType() == OBJECT_TYPE_MAPOBJECT) {
+            if (((CMatrixMapObject *)item)->m_ShadowType == SHADOW_PROJ_DYNAMIC &&
+                ((CMatrixMapObject *)item)->m_Graph->VO()->GetFramesCnt() > 1) {}
             else {
-                (*sb)->RNeed(MR_ShadowProjTex);
+                item->RNeed(MR_ShadowProjTex);
             }
         }
         else {
-            (*sb)->RNeed(MR_ShadowProjTex);
+            item->RNeed(MR_ShadowProjTex);
 
-            if ((*sb)->IsBase() && (*sb)->IsLiveBuilding()) {
-                int side = (*sb)->GetSide();
+            if (item->IsBase() && item->IsLiveBuilding()) {
+                int side = item->GetSide();
                 if (side != 0) {
                     g_MatrixMap->GetSideById(side)->SetStatus(SS_ACTIVE);
                 }
             }
         }
-        ++sb;
     }
 
     if (robots) {
@@ -1636,13 +1634,11 @@ void CMatrixMap::StaticPrepare(int ocnt, bool skip_progress) {
         g_LoadProgress->InitCurLP(ocnt * 2);
     }
 
-    CMatrixMapStatic **sb = m_AllObjects.Buff<CMatrixMapStatic *>();
-    CMatrixMapStatic **se = m_AllObjects.BuffEnd<CMatrixMapStatic *>();
-
-    while (sb < se) {
-        (*sb)->RNeed(MR_Matrix | MR_Graph);
-        if ((*sb)->GetObjectType() != OBJECT_TYPE_MAPOBJECT) {
-            (*sb)->JoinToGroup();
+    for (auto item : m_AllObjects)
+    {
+        item->RNeed(MR_Matrix | MR_Graph);
+        if (item->GetObjectType() != OBJECT_TYPE_MAPOBJECT) {
+            item->JoinToGroup();
             // b0
             // x -8,896
             // y 68,774
@@ -1668,47 +1664,45 @@ void CMatrixMap::StaticPrepare(int ocnt, bool skip_progress) {
             // y 72,302
             // z 51,103
 
-            if ((*sb)->IsBuilding()) {
-                SObjectCore *core = (*sb)->GetCore(DEBUG_CALL_INFO);
-                if ((*sb)->AsBuilding()->m_Kind == BUILDING_BASE) {
+            if (item->IsBuilding()) {
+                SObjectCore *core = item->GetCore(DEBUG_CALL_INFO);
+                if (item->AsBuilding()->m_Kind == BUILDING_BASE) {
                     auto tmp = D3DXVECTOR3(-8.896f, -68.774f, 55.495f);
-                    D3DXVec3TransformCoord(&(*sb)->AsBuilding()->m_TopPoint, &tmp,
+                    D3DXVec3TransformCoord(&item->AsBuilding()->m_TopPoint, &tmp,
                                            &core->m_Matrix);
                 }
-                else if ((*sb)->AsBuilding()->m_Kind == BUILDING_TITAN) {
+                else if (item->AsBuilding()->m_Kind == BUILDING_TITAN) {
                     auto tmp = D3DXVECTOR3(0.455f, 58.688f, 73.993f);
-                    D3DXVec3TransformCoord(&(*sb)->AsBuilding()->m_TopPoint, &tmp,
+                    D3DXVec3TransformCoord(&item->AsBuilding()->m_TopPoint, &tmp,
                                            &core->m_Matrix);
                 }
-                else if ((*sb)->AsBuilding()->m_Kind == BUILDING_ELECTRONIC) {
+                else if (item->AsBuilding()->m_Kind == BUILDING_ELECTRONIC) {
                     auto tmp = D3DXVECTOR3(0.124f, 64.68f, 75.081f);
-                    D3DXVec3TransformCoord(&(*sb)->AsBuilding()->m_TopPoint, &tmp,
+                    D3DXVec3TransformCoord(&item->AsBuilding()->m_TopPoint, &tmp,
                                            &core->m_Matrix);
                 }
-                else if ((*sb)->AsBuilding()->m_Kind == BUILDING_ENERGY) {
+                else if (item->AsBuilding()->m_Kind == BUILDING_ENERGY) {
                     auto tmp = D3DXVECTOR3(0.1f, 110.0f, 51.103f);
-                    D3DXVec3TransformCoord(&(*sb)->AsBuilding()->m_TopPoint, &tmp,
+                    D3DXVec3TransformCoord(&item->AsBuilding()->m_TopPoint, &tmp,
                                            &core->m_Matrix);
                 }
-                else if ((*sb)->AsBuilding()->m_Kind == BUILDING_PLASMA) {
+                else if (item->AsBuilding()->m_Kind == BUILDING_PLASMA) {
                     auto tmp = D3DXVECTOR3(-0.149f, 105.0f, 72.981f);
-                    D3DXVec3TransformCoord(&(*sb)->AsBuilding()->m_TopPoint, &tmp,
+                    D3DXVec3TransformCoord(&item->AsBuilding()->m_TopPoint, &tmp,
                                            &core->m_Matrix);
                 }
 
                 core->Release();
             }
         }
-        ++sb;
         ++n;
     }
 
     // prepare shadows geometry
-    sb = m_AllObjects.Buff<CMatrixMapStatic *>();
-    while (sb < se) {
-        (*sb)->RNeed(MR_ShadowProjGeom);
+    for (auto item : m_AllObjects)
+    {
+        item->RNeed(MR_ShadowProjGeom);
         // ms->FreeDynamicResources();
-        ++sb;
         if (!skip_progress) {
             g_LoadProgress->SetCurLPPos(n++);
         }
@@ -1723,12 +1717,11 @@ void CMatrixMap::Restart(void) {
 
     CDWORDMap dm(g_CacheHeap);
 
-    CMatrixMapStatic **sb = m_AllObjects.Buff<CMatrixMapStatic *>();
-    CMatrixMapStatic **se = m_AllObjects.BuffEnd<CMatrixMapStatic *>();
-    for (; sb < se; ++sb) {
-        if ((*sb)->GetObjectType() == OBJECT_TYPE_MAPOBJECT) {
-            if ((*sb)->IsNotOnMinimap()) {
-                int uid = ((CMatrixMapObject *)(*sb))->m_UID;
+    for (auto item : m_AllObjects)
+    {
+        if (item->GetObjectType() == OBJECT_TYPE_MAPOBJECT) {
+            if (item->IsNotOnMinimap()) {
+                int uid = ((CMatrixMapObject *)item)->m_UID;
                 if (uid >= 0)
                     dm.Set(uid, 0);
             }
@@ -1790,9 +1783,6 @@ void CMatrixMap::Restart(void) {
 
     // minimap rendering
     {
-        CMatrixMapStatic **sb = m_AllObjects.Buff<CMatrixMapStatic *>();
-        CMatrixMapStatic **se = m_AllObjects.BuffEnd<CMatrixMapStatic *>();
-
         DWORD flags = 0;
 
         if (g_Config.m_DrawAllObjectsToMinimap == 1)
@@ -1802,16 +1792,16 @@ void CMatrixMap::Restart(void) {
         }
 
         if (flags != 0) {
-            while (sb < se) {
-                int uid = ((CMatrixMapObject *)(*sb))->m_UID;
+            for (auto item : m_AllObjects)
+            {
+                int uid = ((CMatrixMapObject *)item)->m_UID;
                 if (dm.Get(uid, NULL)) {
                     dm.Del(uid);
                     flags &= ~MR_MiniMap;
-                    (*sb)->RNoNeed(MR_MiniMap);
+                    item->RNoNeed(MR_MiniMap);
                 }
 
-                (*sb)->RNeed(flags);
-                ++sb;
+                item->RNeed(flags);
             }
         }
     }
@@ -1835,11 +1825,10 @@ void CMatrixMap::Restart(void) {
 
 void CMatrixMap::InitObjectsLights(void) {
     // init lights
-    CMatrixMapStatic **sb = m_AllObjects.Buff<CMatrixMapStatic *>();
-    CMatrixMapStatic **se = m_AllObjects.BuffEnd<CMatrixMapStatic *>();
-    for (; sb < se; ++sb) {
-        if ((*sb)->GetObjectType() == OBJECT_TYPE_MAPOBJECT) {
-            ((CMatrixMapObject *)(*sb))->m_Graph->InitLights(CMatrixEffect::GetBBTexI(BBT_POINTLIGHT));
+    for (auto item : m_AllObjects)
+    {
+        if (item->GetObjectType() == OBJECT_TYPE_MAPOBJECT) {
+            ((CMatrixMapObject *)item)->m_Graph->InitLights(CMatrixEffect::GetBBTexI(BBT_POINTLIGHT));
         }
     }
 }
@@ -1910,9 +1899,6 @@ void CMatrixMap::CreatePoolDefaultResources(bool loading) {
         m_Minimap.RenderBackground(nnn, uniq);
 
         {
-            CMatrixMapStatic **sb = m_AllObjects.Buff<CMatrixMapStatic *>();
-            CMatrixMapStatic **se = m_AllObjects.BuffEnd<CMatrixMapStatic *>();
-
             DWORD flags = 0;
 
             if (g_Config.m_DrawAllObjectsToMinimap == 1)
@@ -1921,10 +1907,11 @@ void CMatrixMap::CreatePoolDefaultResources(bool loading) {
                 flags = MR_Matrix | MR_Graph | MR_MiniMap;
             }
 
-            if (flags != 0) {
-                while (sb < se) {
-                    (*sb)->RNeed(flags);
-                    ++sb;
+            if (flags != 0)
+            {
+                for (auto item : m_AllObjects)
+                {
+                    item->RNeed(flags);
                 }
             }
         }

--- a/MatrixGame/src/MatrixMultiSelection.cpp
+++ b/MatrixGame/src/MatrixMultiSelection.cpp
@@ -250,8 +250,8 @@ void CMultiSelection::Update(const Base::CPoint &pos, DWORD mask, SELECT_ENUM ca
                 SETFLAG(m_Flags, MS_FLAG_BUILDINGS);
             }
 
-            if ((m_SelItems.Len() / sizeof(DWORD)) < 9) {
-                m_SelItems.Add<uint32_t>((DWORD)o);
+            if (m_SelItems.size() < 9) {
+                m_SelItems.push_back(o);
                 if (o->IsRobot()) {
                     if (!o->AsRobot()->IsSelected()) {
                         o->AsRobot()->SelectByGroup();
@@ -273,41 +273,36 @@ void CMultiSelection::End(bool add_to_selection) {
     CRect r(m_LT.x, m_LT.y, m_RB.x, m_RB.y);
     r.Normalize();
 
-    if (m_SelItems.Len() > 0 && add_to_selection) {
+    if (!m_SelItems.empty() && add_to_selection) {
         CMatrixSideUnit *ps = g_MatrixMap->GetPlayerSide();
 
-        CMatrixMapStatic **items = m_SelItems.Buff<CMatrixMapStatic *>();
-        CMatrixMapStatic **iteme = m_SelItems.BuffEnd<CMatrixMapStatic *>();
-
-        for (; items < iteme; ++items) {
-            ps->GetCurSelGroup()->AddObject(*items, -4);
+        for (auto item : m_SelItems)
+        {
+            ps->GetCurSelGroup()->AddObject(item, -4);
         }
     }
 
     RemoveSelItems();
 }
 
-bool CMultiSelection::FindItem(const CMatrixMapStatic *o) {
-    CMatrixMapStatic **items = m_SelItems.Buff<CMatrixMapStatic *>();
-    CMatrixMapStatic **iteme = m_SelItems.BuffEnd<CMatrixMapStatic *>();
-
-    for (; items < iteme; ++items) {
-        if (o == (*items)) {
+bool CMultiSelection::FindItem(const CMatrixMapStatic *o)
+{
+    for (auto item : m_SelItems)
+    {
+        if (o == item)
+        {
             return true;
         }
     }
+
     return false;
 }
 
-void CMultiSelection::Remove(const CMatrixMapStatic *o) {
-    CMatrixMapStatic **items = m_SelItems.Buff<CMatrixMapStatic *>();
-    CMatrixMapStatic **iteme = m_SelItems.BuffEnd<CMatrixMapStatic *>();
-
-    for (; items < iteme; ++items) {
-        if (o == (*items)) {
-            *items = *(iteme - 1);
-            m_SelItems.SetLenNoShrink(m_SelItems.Len() - sizeof(DWORD));
-            return;
-        }
+void CMultiSelection::Remove(const CMatrixMapStatic *o)
+{
+    auto item = std::ranges::find(m_SelItems, o);
+    if (item != m_SelItems.end())
+    {
+        m_SelItems.erase(item);
     }
 }

--- a/MatrixGame/src/MatrixMultiSelection.hpp
+++ b/MatrixGame/src/MatrixMultiSelection.hpp
@@ -8,6 +8,8 @@
 
 #include "StringConstants.hpp"
 
+#include <vector>
+
 class CMatrixMapStatic;
 
 typedef void (*SELECT_ENUM)(CMatrixMapStatic *ms, DWORD param);
@@ -37,7 +39,7 @@ class CMultiSelection : public CMain {
 
     int m_TimeBeforeDip;
 
-    CBuf m_SelItems;
+    std::vector<CMatrixMapStatic*> m_SelItems;
 
     static int m_Time;
 
@@ -61,7 +63,7 @@ class CMultiSelection : public CMain {
         RESETFLAG(m_Flags, MS_FLAG_BUILDINGS);
         RESETFLAG(m_Flags, MS_FLAG_ROBOTS);
 
-        m_SelItems.Clear();
+        m_SelItems.clear();
     }
 
 public:

--- a/MatrixGame/src/MatrixVisiCalc.cpp
+++ b/MatrixGame/src/MatrixVisiCalc.cpp
@@ -482,7 +482,7 @@ void CMatrixMap::CheckCandidate(SCalcVisRuntime &visRuntime, CMatrixMapGroup *ma
             D3DXVECTOR3 maxs(mins.x + float(MAP_GROUP_SIZE * GLOBAL_SCALE),
                              mins.y + float(MAP_GROUP_SIZE * GLOBAL_SCALE), WATER_LEVEL);
             if (m_Camera.IsInFrustum(mins, maxs)) {
-                m_VisWater->Add<D3DXVECTOR2>(mapGroup->GetPos0());
+                m_VisWater.push_back(mapGroup->GetPos0());
             }
         }
     }
@@ -655,7 +655,7 @@ void CMatrixMap::CalcMapGroupVisibility(void) {
     int iminy = (int)floor(miny * (1.0 / (MAP_GROUP_SIZE * GLOBAL_SCALE))) - 1;
     int imaxy = (int)(maxy * (1.0 / (MAP_GROUP_SIZE * GLOBAL_SCALE))) + 1;
 
-    m_VisWater->Clear();
+    m_VisWater.clear();
 
     // DM("TIME", "TIME_STEP1 " + CStr(iminx) + " " + CStr(iminy)+ " " + CStr(imaxx)+ " " + CStr(imaxy));
 
@@ -704,7 +704,7 @@ void CMatrixMap::CalcMapGroupVisibility(void) {
                 }
 
                 if (m_Camera.IsInFrustum(p0, p1)) {
-                    m_VisWater->Add<D3DXVECTOR2>(*(D3DXVECTOR2 *)&p0);
+                    m_VisWater.push_back(*(D3DXVECTOR2 *)&p0);
                 }
             invisible_w:;
             }

--- a/MatrixLib/Base/Pack.cpp
+++ b/MatrixLib/Base/Pack.cpp
@@ -8,6 +8,7 @@
 #include <utility>
 #include <tuple> // for std::tie
 #include <cctype> // for std::toupper
+#include <algorithm>
 
 #include <utils.hpp>
 
@@ -2325,108 +2326,126 @@ int CPackFile::FindFirst(const std::string& path, DWORD Attr, SSearchRec &S) {
 //***************** КЛАСС - КОЛЛЕКЦИЯ ПАКЕТНЫХ ФАЙЛОВ ******************
 //**********************************************************************
 
-void CPackCollection::Clear(void) {
-    PCPackFile *ff = m_PackFiles.Buff<PCPackFile>();
-    PCPackFile *fe = m_PackFiles.BuffEnd<PCPackFile>();
-    for (; ff < fe; ++ff) {
-        HDelete(CPackFile, *ff, m_Heap);
+void CPackCollection::Clear(void)
+{
+    for (auto item : m_PackFiles)
+    {
+        HDelete(CPackFile, item, nullptr);
     }
-    m_PackFiles.Clear();
+    m_PackFiles.clear();
 }
 
-void CPackCollection::AddPacketFile(const wchar *name) {
-    m_PackFiles.Expand(sizeof(PCPackFile));
-    PCPackFile f = HNew(m_Heap) CPackFile(m_Heap, name);
-    *(m_PackFiles.BuffEnd<PCPackFile>() - 1) = f;
+void CPackCollection::AddPacketFile(const wchar *name)
+{
+    auto f = HNew(m_Heap) CPackFile(m_Heap, name);
+    m_PackFiles.push_back(f);
 }
 
-void CPackCollection::DelPacketFile(const wchar *name) {
-    PCPackFile *ff = m_PackFiles.Buff<PCPackFile>();
-    PCPackFile *fe = m_PackFiles.BuffEnd<PCPackFile>();
-    for (; ff < fe; ++ff) {
-        if ((*ff)->GetName() == name) {
-            *ff = *(fe - 1);
-            m_PackFiles.SetLenNoShrink(m_PackFiles.Len() - sizeof(PCPackFile));
-            return;
-        }
+void CPackCollection::DelPacketFile(const wchar *name)
+{
+    auto pred = [name](const CPackFile* item){ return item->GetName() == name; };
+    auto item = std::ranges::find_if(m_PackFiles, pred);
+    if (item != m_PackFiles.end())
+    {
+        m_PackFiles.erase(item);
     }
 }
 
-bool CPackCollection::OpenPacketFiles(void) {
-    PCPackFile *ff = m_PackFiles.Buff<PCPackFile>();
-    PCPackFile *fe = m_PackFiles.BuffEnd<PCPackFile>();
-    for (; ff < fe; ++ff) {
-        if (!(*ff)->OpenPacketFile())
+bool CPackCollection::OpenPacketFiles(void)
+{
+    size_t iter = 0;
+    for (; iter < m_PackFiles.size(); ++iter)
+    {
+        if (!m_PackFiles[iter]->OpenPacketFile())
+        {
             break;
+        }
     }
 
-    if (ff < fe) {
-        //*********** Ошибка открытия одного из пакетных файлов **********
-        PCPackFile *fff = m_PackFiles.Buff<PCPackFile>();
-        for (; fff < ff; ++fff) {
-            (*fff)->ClosePacketFile();
+    // if not all the files were opened, we'll close the open ones
+    if (iter != m_PackFiles.size())
+    {
+        for (; iter >= 0; --iter)
+        {
+            m_PackFiles[iter]->ClosePacketFile();
         }
+
         return false;
     }
+
     return true;
 }
 
-bool CPackCollection::ClosePacketFiles(void) {
-    PCPackFile *ff = m_PackFiles.Buff<PCPackFile>();
-    PCPackFile *fe = m_PackFiles.BuffEnd<PCPackFile>();
-    for (; ff < fe; ++ff) {
-        (*ff)->ClosePacketFile();
+bool CPackCollection::ClosePacketFiles(void)
+{
+    for (auto item : m_PackFiles)
+    {
+        item->ClosePacketFile();
     }
+
     return true;
 }
 
-bool CPackCollection::OpenPacketFilesEx(void) {
-    PCPackFile *ff = m_PackFiles.Buff<PCPackFile>();
-    PCPackFile *fe = m_PackFiles.BuffEnd<PCPackFile>();
-    for (; ff < fe; ++ff) {
-        if (!(*ff)->OpenPacketFileEx())
+bool CPackCollection::OpenPacketFilesEx(void)
+{
+    size_t iter = 0;
+    for (; iter < m_PackFiles.size(); ++iter)
+    {
+        if (!m_PackFiles[iter]->OpenPacketFileEx())
+        {
             break;
+        }
     }
 
-    if (ff < fe) {
-        //*********** Ошибка открытия одного из пакетных файлов **********
-        PCPackFile *fff = m_PackFiles.Buff<PCPackFile>();
-        for (; fff < ff; ++fff) {
-            (*fff)->ClosePacketFileEx();
+    // if not all the files were opened, we'll close the open ones
+    if (iter != m_PackFiles.size())
+    {
+        for (; iter >= 0; --iter)
+        {
+            m_PackFiles[iter]->ClosePacketFileEx();
         }
+
         return false;
     }
+
     return true;
 }
 
-bool CPackCollection::ClosePacketFilesEx(void) {
-    PCPackFile *ff = m_PackFiles.Buff<PCPackFile>();
-    PCPackFile *fe = m_PackFiles.BuffEnd<PCPackFile>();
-    for (; ff < fe; ++ff) {
-        (*ff)->ClosePacketFileEx();
+bool CPackCollection::ClosePacketFilesEx(void)
+{
+    for (auto item : m_PackFiles)
+    {
+        item->ClosePacketFileEx();
     }
+
     return true;
 }
 
 //******** Процедуры для работы файлами ***********//
 
-bool CPackCollection::FileExists(const std::string& name) {
-    PCPackFile *ff = m_PackFiles.Buff<PCPackFile>();
-    PCPackFile *fe = m_PackFiles.BuffEnd<PCPackFile>();
-    for (; ff < fe; ++ff) {
-        if ((*ff)->FileExists(name))
+bool CPackCollection::FileExists(const std::string& name)
+{
+    for (auto item : m_PackFiles)
+    {
+        if(item->FileExists(name))
+        {
             return true;
+        }
     }
+
     return false;
 }
 
-bool CPackCollection::PathExists(const std::string& path) {
-    PCPackFile *ff = m_PackFiles.Buff<PCPackFile>();
-    PCPackFile *fe = m_PackFiles.BuffEnd<PCPackFile>();
-    for (; ff < fe; ++ff) {
-        if ((*ff)->PathExists(path))
+bool CPackCollection::PathExists(const std::string& path)
+{
+    for (auto item : m_PackFiles)
+    {
+        if(item->PathExists(path))
+        {
             return true;
+        }
     }
+
     return false;
 }
 
@@ -2435,14 +2454,14 @@ DWORD CPackCollection::Open(const std::string& name, DWORD modeopen) {
     DWORD Handle;
     DWORD Counter = 0;
 
-    PCPackFile *ff = m_PackFiles.Buff<PCPackFile>();
-    PCPackFile *fe = m_PackFiles.BuffEnd<PCPackFile>();
-    for (; ff < fe; ++ff) {
-        Handle = (*ff)->Open(name, modeopen);
+    for (auto item : m_PackFiles)
+    {
+        Handle = item->Open(name, modeopen);
         if (Handle != 0xFFFFFFFF)
             break;
         ++Counter;
     }
+
     if (Handle == 0xFFFFFFFF)
         return 0xFFFFFFFF;
     return Handle + (Counter << MAX_VIRTUAL_HANDLE_COUNT_BITS);
@@ -2451,7 +2470,7 @@ DWORD CPackCollection::Open(const std::string& name, DWORD modeopen) {
 bool CPackCollection::Close(DWORD Handle) {
     ASSERT(MAX_VIRTUAL_HANDLE_COUNT == (1 << MAX_VIRTUAL_HANDLE_COUNT_BITS));
     int number = Handle >> MAX_VIRTUAL_HANDLE_COUNT_BITS;
-    PCPackFile P = GetPacketFile(number);
+    CPackFile* P = GetPacketFile(number);
     if (P == NULL)
         return false;
     return P->Close(Handle & (MAX_VIRTUAL_HANDLE_COUNT - 1));
@@ -2461,7 +2480,7 @@ bool CPackCollection::Read(DWORD Handle, void *Buf, int Size) {
     ASSERT(MAX_VIRTUAL_HANDLE_COUNT == (1 << MAX_VIRTUAL_HANDLE_COUNT_BITS));
 
     int number = Handle >> MAX_VIRTUAL_HANDLE_COUNT_BITS;
-    PCPackFile P = GetPacketFile(number);
+    CPackFile* P = GetPacketFile(number);
     if (P == NULL)
         return false;
     return P->Read(Handle & (MAX_VIRTUAL_HANDLE_COUNT - 1), Buf, Size);
@@ -2472,7 +2491,7 @@ bool CPackCollection::Read(DWORD Handle, void *Buf, int Size) {
 //    ASSERT(MAX_VIRTUAL_HANDLE_COUNT == (1 << MAX_VIRTUAL_HANDLE_COUNT_BITS));
 //
 //    int number = Handle >> MAX_VIRTUAL_HANDLE_COUNT_BITS;
-//    PCPackFile P = GetPacketFile(number);
+//    CPackFile* P = GetPacketFile(number);
 //    if (P==NULL) return false;
 //    return P->Write(Handle & (MAX_VIRTUAL_HANDLE_COUNT-1),Buf,Size);
 //}
@@ -2481,7 +2500,7 @@ bool CPackCollection::SetPos(DWORD Handle, DWORD Pos, int ftype) {
     ASSERT(MAX_VIRTUAL_HANDLE_COUNT == (1 << MAX_VIRTUAL_HANDLE_COUNT_BITS));
 
     int number = Handle >> MAX_VIRTUAL_HANDLE_COUNT_BITS;
-    PCPackFile P = GetPacketFile(number);
+    CPackFile* P = GetPacketFile(number);
     if (P == NULL)
         return false;
     return P->SetPos(Handle & (MAX_VIRTUAL_HANDLE_COUNT - 1), Pos, ftype);
@@ -2491,7 +2510,7 @@ DWORD CPackCollection::GetPos(DWORD Handle) {
     ASSERT(MAX_VIRTUAL_HANDLE_COUNT == (1 << MAX_VIRTUAL_HANDLE_COUNT_BITS));
 
     int number = Handle >> MAX_VIRTUAL_HANDLE_COUNT_BITS;
-    PCPackFile P = GetPacketFile(number);
+    CPackFile* P = GetPacketFile(number);
     if (P == NULL)
         return 0xFFFFFFFF;
     return P->GetPos(Handle & (MAX_VIRTUAL_HANDLE_COUNT - 1));
@@ -2501,7 +2520,7 @@ DWORD CPackCollection::GetSize(DWORD Handle) {
     ASSERT(MAX_VIRTUAL_HANDLE_COUNT == (1 << MAX_VIRTUAL_HANDLE_COUNT_BITS));
 
     int number = Handle >> MAX_VIRTUAL_HANDLE_COUNT_BITS;
-    PCPackFile P = GetPacketFile(number);
+    CPackFile* P = GetPacketFile(number);
     if (P == NULL)
         return 0xFFFFFFFF;
     return P->GetSize(Handle & (MAX_VIRTUAL_HANDLE_COUNT - 1));
@@ -2511,25 +2530,23 @@ DWORD CPackCollection::GetHandle(DWORD Handle) {
     ASSERT(MAX_VIRTUAL_HANDLE_COUNT == (1 << MAX_VIRTUAL_HANDLE_COUNT_BITS));
 
     int number = Handle >> MAX_VIRTUAL_HANDLE_COUNT_BITS;
-    PCPackFile P = GetPacketFile(number);
+    CPackFile* P = GetPacketFile(number);
     if (P == NULL)
         return 0xFFFFFFFF;
     return P->GetHandle(Handle & (MAX_VIRTUAL_HANDLE_COUNT - 1));
 }
 
-// bool  CPackCollection::UnpackFile(const std::string& souname,const std::string& desname)
-//{
-//    PCPackFile *ff = m_PackFiles.Buff<PCPackFile>();
-//    PCPackFile *fe = m_PackFiles.BuffEnd<PCPackFile>();
-//    for(;ff < fe; ++ff)
-//    {
-//        if ((*ff)->FileExists(souname))
-//        {
-//            return (*ff)->UnpackFile(souname,desname);
-//        }
-//    }
-//    return false;
-//}
+// bool CPackCollection::UnpackFile(const std::string& souname,const std::string& desname)
+// {
+//     for (auto item : m_PackFiles)
+//     {
+//         if (item->FileExists(souname))
+//         {
+//             return item->UnpackFile(souname,desname);
+//         }
+//     }
+//     return false;
+// }
 
 }  // namespace Base
 

--- a/MatrixLib/Base/Pack.hpp
+++ b/MatrixLib/Base/Pack.hpp
@@ -6,12 +6,13 @@
 #ifndef PACK_INCLUDE
 #define PACK_INCLUDE
 
-#include <string>
-
 #include "CException.hpp"
 #include "CMain.hpp"
 #include "CHeap.hpp"
 #include "CBuf.hpp"
+
+#include <string>
+#include <vector>
 
 namespace Base {
 
@@ -311,12 +312,10 @@ public:
     }
 };
 
-typedef CPackFile *PCPackFile;
-
 class CPackCollection : public CMain {
 public:
     CHeap *m_Heap;
-    CBuf m_PackFiles;
+    std::vector<CPackFile*> m_PackFiles;
 
 public:
     CPackCollection(CHeap *heap) : m_Heap(heap) {}
@@ -331,7 +330,7 @@ public:
     bool ClosePacketFiles(void);
     bool OpenPacketFilesEx(void);
     bool ClosePacketFilesEx(void);
-    CPackFile *GetPacketFile(int i) { return m_PackFiles.Buff<PCPackFile>()[i]; };
+    CPackFile *GetPacketFile(int i) { return m_PackFiles[i]; };
     //******** Процедуры для работы файлами ***********//
     bool FileExists(const std::string& name);
     bool PathExists(const std::string& path);


### PR DESCRIPTION
Convert some of CBuf usages into std::vector.
In some cases it results in a vector of pointers, which most probably can be converted into normal vector of objects, but not in this PR.