### PR TITLE
Link binary statically in release mode and optimize its size

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,8 @@ else()
     # All the warnings below are potential bugs.
     # -Wno-... options should be fixed and removed.
     list(APPEND COMPILE_OPTIONS
+        $<$<CONFIG:Release>:-Os>
+
         -Wall
         -Wextra
         -Wpedantic
@@ -66,6 +68,10 @@ else()
         -Wno-strict-aliasing
         -Wno-empty-body
         -Wno-pedantic
+    )
+
+    set(LINK_OPTIONS
+        -static -s
     )
 endif()
 

--- a/MatrixGame/CMakeLists.txt
+++ b/MatrixGame/CMakeLists.txt
@@ -94,3 +94,9 @@ target_sources(MatrixGame PRIVATE
 )
 
 target_link_libraries(MatrixGame MatrixGameInternal)
+
+target_link_options(
+    MatrixGame
+    PRIVATE
+        ${LINK_OPTIONS}
+)

--- a/MatrixGame/src/MatrixCamera.cpp
+++ b/MatrixGame/src/MatrixCamera.cpp
@@ -764,7 +764,7 @@ void CMatrixCamera::BeforeDraw(void) {
 }
 
 float CMatrixCamera::GetFrustPlaneDist(EFrustumPlane plane, const D3DXVECTOR3 &pos, const D3DXVECTOR3 &dir) {
-    const SPlane *pl;
+    const SPlane *pl = nullptr;
 
     switch (plane) {
         case FPLANE_LEFT:

--- a/MatrixGame/src/MatrixSide.cpp
+++ b/MatrixGame/src/MatrixSide.cpp
@@ -6873,7 +6873,7 @@ void CMatrixSideUnit::TaktPL(int onlygroup) {
     CPoint tp;
     CMatrixMapStatic *obj;
     CMatrixBuilding *building;
-    CMatrixRobotAI *robot, *robot2;
+    CMatrixRobotAI *robot{nullptr}, *robot2{nullptr};
     bool orderok[MAX_LOGIC_GROUP];
 
     // Запускаем логику раз в 100 тактов

--- a/MatrixLib/3G/BigIB.hpp
+++ b/MatrixLib/3G/BigIB.hpp
@@ -177,7 +177,7 @@ __inline void CBigIB::ReleaseBuffers(void) {
 }
 
 __inline void CBigIB::AddSource(SBigIBSource *src) {
-    int index;
+    int index = 0;
 
     if (m_IB_count == 0) {
         ASSERT(src->size <= BIB_MAX_SIZE);

--- a/MatrixLib/3G/BigVB.hpp
+++ b/MatrixLib/3G/BigVB.hpp
@@ -265,7 +265,7 @@ inline void CBigVB<V>::ReleaseBuffers(void) {
 
 template <class V>
 inline void CBigVB<V>::AddSource(SBigVBSource<V> *src) {
-    int index;
+    int index = 0;
 
     if (m_VB_count == 0) {
         ASSERT(src->size <= BVB_MAX_SIZE);


### PR DESCRIPTION
Now binary compiled by github action will not depend on your local env having the same GCC installed or not.
As static linkage increases a binary size some optimizations will be added to reduce it a bit back.