### PR TITLE
Reduce randomness

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ else()
     # -Wno-... options should be fixed and removed.
     list(APPEND COMPILE_OPTIONS
         $<$<CONFIG:Release>:-Os>
+        -ftrivial-auto-var-init=zero
 
         -Wall
         -Wextra

--- a/MatrixGame/src/DevConsole.cpp
+++ b/MatrixGame/src/DevConsole.cpp
@@ -92,7 +92,7 @@ static void hTestSpdTrace(
     [[maybe_unused]] const std::wstring& cmd,
     [[maybe_unused]] const std::wstring& params)
 {
-    srand(1);
+    random::seed(1);
     D3DXVECTOR3 pos1, pos2;
 
     DWORD time1 = timeGetTime();

--- a/MatrixGame/src/Effects/MatrixEffectExplosion.cpp
+++ b/MatrixGame/src/Effects/MatrixEffectExplosion.cpp
@@ -13,6 +13,8 @@
 #include "MatrixEffectExplosion.hpp"
 #include "MatrixEffectPointLight.hpp"
 
+#include <random.hpp>
+
 // explosions
 const SExplosionProperties ExplosionNormal = {
         0,    // float min_speed;
@@ -430,7 +432,7 @@ CMatrixEffectExplosion::CMatrixEffectExplosion(const D3DXVECTOR3 &pos, const SEx
         m_Deb[i].u1.s1.u2.s4.angley = FSRND(1);
         m_Deb[i].u1.s1.u2.s4.anglep = FSRND(1);
         m_Deb[i].u1.s1.u2.s4.angler = FSRND(1);
-        m_Deb[i].index = dt_idx + (rand() % dt_cnt);
+        m_Deb[i].index = dt_idx + (random::Rnd() % dt_cnt);
 
         ASSERT(m_Deb[i].index >= 0);
 

--- a/MatrixGame/src/MatrixGame.cpp
+++ b/MatrixGame/src/MatrixGame.cpp
@@ -172,7 +172,7 @@ static void static_init(void) {
 
 void CGame::Init(HINSTANCE inst, HWND wnd, wchar *map, uint32_t seed, SRobotsSettings *set, wchar *lang,
                  wchar *txt_start, wchar *txt_win, wchar *txt_loss, wchar *planet) {
-    srand(seed);
+    random::seed(seed);
     static_init();
 
     DTRACE();

--- a/MatrixGame/src/MatrixLogic.cpp
+++ b/MatrixGame/src/MatrixLogic.cpp
@@ -15,6 +15,8 @@
 #include "MatrixGameDll.hpp"
 #include "MatrixMultiSelection.hpp"
 
+#include <random.hpp>
+
 // CPoint MatrixDir45[8]={	CPoint(-1,0),	CPoint(1,0),CPoint(0,-1),CPoint(0,1),
 //						CPoint(-1,-1),CPoint(1,1),CPoint(-1,1),CPoint(1,-1)};
 
@@ -45,7 +47,6 @@ CMatrixMapLogic::CMatrixMapLogic() : CMatrixMap() {
 
     m_TaktNext = 0;
 
-    m_Rnd = rand();
     Rnd(0, 1);
 
     m_GatherInfoLast = 0;
@@ -99,32 +100,22 @@ void CMatrixMapLogic::Clear() {
 
 int CMatrixMapLogic::Rnd() {
     DTRACE();
-
-    m_Rnd = 16807 * (m_Rnd % 127773) - 2836 * (m_Rnd / 127773);
-    if (m_Rnd <= 0)
-        m_Rnd = m_Rnd + 2147483647;
-    return m_Rnd - 1;
+    return random::Rnd();
 }
 
 double CMatrixMapLogic::RndFloat(void) {
     DTRACE();
-
-    return float(Rnd()) / float(2147483647 - 2);
+    return random::RndFloat();
 }
 
 int CMatrixMapLogic::Rnd(int zmin, int zmax) {
     DTRACE();
-
-    if (zmin <= zmax)
-        return zmin + (Rnd() % (zmax - zmin + 1));
-    else
-        return zmax + (Rnd() % (zmin - zmax + 1));
+    return random::Rnd(zmin, zmax);
 }
 
 double CMatrixMapLogic::RndFloat(double zmin, double zmax) {
     DTRACE();
-
-    return zmin + RndFloat() * (zmax - zmin);
+    return random::RndFloat(zmin, zmax);
 }
 
 void CMatrixMapLogic::GatherInfo(int type) {

--- a/MatrixGame/src/MatrixLogic.hpp
+++ b/MatrixGame/src/MatrixLogic.hpp
@@ -72,8 +72,6 @@ public:
     // int m_Takt;				// Game takt
     int m_TaktNext;
 
-    int m_Rnd;
-
     int m_GatherInfoLast;
 
 public:

--- a/MatrixGame/src/MatrixRobot.cpp
+++ b/MatrixGame/src/MatrixRobot.cpp
@@ -18,6 +18,8 @@
 #include "Effects/MatrixEffectSelection.hpp"
 #include "Effects/MatrixEffectExplosion.hpp"
 
+size_t CMatrixRobotAI::nextUID{0};
+
 void SWeaponRepairData::Release(void) {
     m_b0.Release();
     m_b1.Release();
@@ -2928,7 +2930,7 @@ static bool CollisionCallback(
                                     0) {  // И движется приблезительно в одну сторону
 
                                     if ((pCurrBot->m_Velocity.x * vDist.x + pCurrBot->m_Velocity.y * vDist.y) > 0 &&
-                                        DWORD(pCurrBot) < DWORD(data->robot))
+                                        pCurrBot->UID < data->robot->UID)
                                         ;  // Только один из двух роботов моежт двигатся
                                     else {
                                         data->stop = true;
@@ -3030,7 +3032,7 @@ static bool CollisionCallback(
                                 0) {  // И движется приблезительно в одну сторону
 
                                 if ((pCurrBot->m_Velocity.x * vDist.x + pCurrBot->m_Velocity.y * vDist.y) > 0 &&
-                                    DWORD(pCurrBot) < DWORD(data->robot))
+                                    pCurrBot->UID < data->robot->UID)
                                     ;  // Только один из двух роботов моежт двигатся
                                 else {
                                     data->far_col = true;

--- a/MatrixGame/src/MatrixRobot.hpp
+++ b/MatrixGame/src/MatrixRobot.hpp
@@ -233,7 +233,8 @@ public:
     }
 };
 
-class CMatrixRobotAI : public CMatrixRobot {
+class CMatrixRobotAI : public CMatrixRobot
+{
     CTextureManaged *m_BigTexture;
     CTextureManaged *m_MedTexture;
 #ifdef USE_SMALL_TEXTURE_IN_ROBOT_ICON
@@ -303,6 +304,15 @@ class CMatrixRobotAI : public CMatrixRobot {
     CMatrixEffectSelection *m_Selection;
 
     int m_LastDelayDamageSide;
+
+///////////////////////////////////////////////////////////////////////
+// each robot will have its own unique ID, so collision detection will
+// compare them by ID instead of memory addresses
+private:
+    static size_t nextUID;
+public:
+    const size_t UID{++nextUID};
+///////////////////////////////////////////////////////////////////////
 
 public:
     DWORD m_SoundChassis;

--- a/MatrixGame/src/MatrixWater.cpp
+++ b/MatrixGame/src/MatrixWater.cpp
@@ -7,6 +7,8 @@
 #include "MatrixMap.hpp"
 #include <math.h>
 
+#include <random.hpp>
+
 CTextureManaged *SInshorewave::m_Tex;
 D3D_VB SInshorewave::m_VB;
 int SInshorewave::m_VB_ref;
@@ -191,7 +193,7 @@ CMatrixWater::CMatrixWater() : CMain() {
         // h[i] = (float)(rand()%255)/255.0f;
         // r[i] = (float)(rand()%1024)/2500.0f;//3024.0f;
         r[i] = (float)512 / 2500.0f;  // 3024.0f;
-        f[i] = rand() % (SIN_TABLE_SIZE - 1);
+        f[i] = random::Rnd() % (SIN_TABLE_SIZE - 1);
     }
 
     m_angle = 0;

--- a/MatrixLib/3G/Math3D.hpp
+++ b/MatrixLib/3G/Math3D.hpp
@@ -5,14 +5,14 @@
 
 #pragma once
 
-#include <cmath>
-
 #include "d3d9.h"
 #include "d3dx9tex.h"
 
 #include "CHeap.hpp"
 #include "CMain.hpp"
 #include "CException.hpp"
+
+#include <random.hpp>
 
 using namespace Base; // TODO: remove
 
@@ -32,11 +32,6 @@ using namespace Base; // TODO: remove
 
 #define LERPFLOAT(k, c1, c2)  (((k) * (float(c2) - float(c1))) + float(c1))
 #define LERPVECTOR(k, v1, v2) (((k) * ((v2) - (v1))) + (v1))
-
-#define RND(from, to) ((double)rand() * (1.0 / (RAND_MAX)) * (fabs(double((to) - (from)))) + (from))
-#define FRND(x)       ((float)(RND(0, (x))))
-#define FSRND(x)      (FRND(2.0f * (x)) - float(x))
-#define IRND(n)       Double2Int(RND(0, double(n) - 0.55))
 
 #define KSCALE(k, k1, k2) ((k) < (k1) ? 0.0f : (k) > (k2) ? 1.0f : ((k) - (k1)) / ((k2) - (k1)))
 

--- a/MatrixLib/Base/CHeap.hpp
+++ b/MatrixLib/Base/CHeap.hpp
@@ -229,7 +229,7 @@ inline void *CHeap::AllocClearEx(void *buf, uint32_t size, const char *file, int
 #endif // MEM_SPY_ENABLE
 
 inline void *CHeap::Alloc(size_t size) {
-    void *buf = malloc(size);
+    void *buf = calloc(size, 1);
     if (!buf) AllocationError(size);
     return buf;
 }

--- a/MatrixLib/Base/Tracer.hpp
+++ b/MatrixLib/Base/Tracer.hpp
@@ -6,6 +6,8 @@
 #ifndef TRACER_HPP
 #define TRACER_HPP
 
+#include <string>
+#include <cstdint>
 #include <utils.hpp>
 
 #include <windows.h>

--- a/MatrixLib/Base/random.cpp
+++ b/MatrixLib/Base/random.cpp
@@ -1,0 +1,54 @@
+#include <cmath>
+
+namespace random
+{
+
+void seed(unsigned int val)
+{
+    srand(val);
+}
+
+int Rnd()
+{
+    return rand();
+}
+
+double RndFloat()
+{
+    return float(Rnd()) / float(2147483647 - 2);
+}
+
+int Rnd(int zmin, int zmax)
+{
+    if (zmin <= zmax)
+        return zmin + (Rnd() % (zmax - zmin + 1));
+    else
+        return zmax + (Rnd() % (zmin - zmax + 1));
+}
+
+double RndFloat(double zmin, double zmax)
+{
+    return zmin + RndFloat() * (zmax - zmin);
+}
+
+} // namespace random
+
+double RND(int from, int to)
+{
+    return ((double)random::Rnd() * (1.0 / (RAND_MAX)) * (fabs(double((to) - (from)))) + (from));
+}
+
+float FRND(int x)
+{
+    return ((float)(RND(0, (x))));
+}
+
+float FSRND(int x)
+{
+    return (FRND(2.0f * (x)) - float(x));
+}
+
+int IRND(int n)
+{
+    return static_cast<int>(std::round(RND(0, double(n) - 0.55)));
+}

--- a/MatrixLib/Base/random.hpp
+++ b/MatrixLib/Base/random.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+namespace random
+{
+
+void seed(unsigned int val);
+
+int Rnd();
+double RndFloat();
+int Rnd(int zmin, int zmax);
+double RndFloat(double zmin, double zmax);
+
+} // namespace random
+
+double RND(int from, int to);
+float FRND(int x);
+float FSRND(int x);
+int IRND(int n);

--- a/MatrixLib/CMakeLists.txt
+++ b/MatrixLib/CMakeLists.txt
@@ -43,6 +43,7 @@ set(BASE_SOURCES
     Base/Pack.cpp
     Base/Registry.cpp
     Base/Tracer.cpp
+    Base/random.cpp
 )
 set(BASE_HEADERS
     Base/BaseDef.hpp


### PR DESCRIPTION
One step closer to make the game behaviour strictly deterministic.
What's done:
- all kinds of random number generator functions are moved to separate unit (`random.hpp/cpp`)
- all the allocated memory (both stack and heap) is zero-initialized (works only with GCC, MSVC doesn't have available compiler option for it)
- weird objects address comparison used in collision detection algorithm is replaced with unique robot IDs