### PR TITLE
Hotfix: CHEATS_ON was overwritten by BUILD_EXE

### DIFF
--- a/MatrixGame/CMakeLists.txt
+++ b/MatrixGame/CMakeLists.txt
@@ -55,10 +55,11 @@ target_link_libraries(
 )
 
 if(MATRIXGAME_CHEATS)
-    set_source_files_properties(
-        src/MatrixFormGame.cpp
-        PROPERTIES
-            COMPILE_DEFINITIONS CHEATS_ON)
+    set_property(
+            SOURCE src/MatrixFormGame.cpp
+            APPEND
+            PROPERTY COMPILE_DEFINITIONS CHEATS_ON
+    )
 endif()
 
 add_matrix_directory(src/Effects)
@@ -71,11 +72,12 @@ if(MATRIXGAME_BUILD_DLL)
     # remove lib prefix from the DLL name (for GCC build)
     set_target_properties(MatrixGame PROPERTIES PREFIX "")
 else()
-    set_source_files_properties(
+    set_property(
+            SOURCE
             src/MatrixFormGame.cpp
             src/MatrixGame.cpp
-            PROPERTIES
-            COMPILE_DEFINITIONS BUILD_EXE
+            APPEND
+            PROPERTY COMPILE_DEFINITIONS BUILD_EXE
     )
     add_executable(MatrixGame)
 endif()


### PR DESCRIPTION
Hot fix for what my last PR changed.
The CHEATS_ON definition for one file was replaced by BUILD_EXE instead of both of them going along.
So you couldn't use cheats inside EXE build.